### PR TITLE
Fix incorrect enum mapping

### DIFF
--- a/packages/incidentportal/src/components/questions/FoundationTypeQuestion.vue
+++ b/packages/incidentportal/src/components/questions/FoundationTypeQuestion.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       },
       {
         label: "Ondiep op staal",
-        value: Type.SteelPile,
+        value: Type.NoPile,
         image: "options/type_staal"
       },
       {


### PR DESCRIPTION
"Ondiep op staal" should map to `FoundationType.NoPile` instead of `FoundationType.SteelPile`.